### PR TITLE
Add autoformatting on save with Black extension, timings for detection, check last frame

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "streetsidesoftware.code-spell-checker",
+    "ms-python.black-formatter"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+}


### PR DESCRIPTION
I made a few changes and improvements (remember, you can click **Files changed** at the top of this to see the code changes):

1. I added a `.vscode/` directory, which includes 2 files.  The first one, `./vscode/extensions.json` is a list of recommended VSCode extensions to install.  It includes the code spell checker we installed together, but also a new extension called [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).  It will automatically format the code whenever we save (so we don't have to do it).  You'll need to install this extension for it to work (I can help if you're not sure how).  The other file, `.vscode/settings.json`, tells VSCode to auto-format when we save.
2. I made a change add a note about a bug with not being able to run the YOLO-Fish model on Mac's GPUs (we run on CPU).  Maybe I'll be able to fix this i the future, and I wanted to remember how I did it.
3. I did some experiments last night to make the YOLO-Fish model faster/smaller, and needed a way to see how long the detection was taking, so I added some logging to `detect()` to print out the times.  It only prints if you add `--log-level DEBUG` when you run the program (i.e., it won't usually print).  Unfortunately, my experiment didn't make it go faster, so I've left things as they are with the model.
4. I made a change to the logic that determines whether to skip a frame.  Currently, we don't check the final frame, and I think that might mean we miss a fish.  This fixes it so we do.
5. The other changes are from Black reformatting our code to move things around, remove empty space, etc.