### PR TITLE
Fix ffmpeg options for better video encoding support

### DIFF
--- a/src/clip_manager.py
+++ b/src/clip_manager.py
@@ -159,6 +159,8 @@ class ClipManager:
                         "libx264",  # use H.264 for video codec to maximize compatibility
                         "-c:a",
                         "aac",  # use Advanced Audio Coding (AAC) for audio compatibility
+                        "-pix_fmt",  # use YUV planar color space with 4:2:0 chroma subsampling (QuickTime)
+                        "yuv420p",  # see https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers
                         clip_filename,
                     ]
                 )


### PR DESCRIPTION
It looks like this issue with QuickTime not being able to play the video on some Macs is common, and the ffmpeg docs talk about a fix: https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers

We need to use a different [chroma subsubsampling](https://en.wikipedia.org/wiki/Chroma_subsampling) approach, which this PR does.

I've tested it on my machine, and it works fine.  The real test would be to try it on the Mac that couldn't play the other file.