### PR TITLE
Add -i option to include bounding box images in clips directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ python3 action.py
 
 usage: action.py [-h] [-e {terrestrial,aquatic}] [-b BUFFER] [-c CONFIDENCE]
                  [-m MIN_DURATION] [-f SKIP_FRAMES] [-d] [-o OUTPUT_DIR] [-s]
-                 [--log-level {DEBUG,INFO,WARNING,ERROR}]
+                 [-i] [--log-level {DEBUG,INFO,WARNING,ERROR}]
                  filename [filename ...]
 action.py: error: the following arguments are required: filename
 ```
@@ -76,6 +76,7 @@ Action can be configured to run in different ways using various arguments and fl
 | `-d`, `--delete-previous-clips` | Whether to delete clips from previous interrupted or old runs before processing a video again. | `--delete-previous-clips` |
 | `-o`, `--output-dir` | Output directory to use for all clips. | `--output-dir ./output` |
 | `-s`, `--show-detections` | Whether to visually show detection frames with bounding boxes. | `--show-detections` |
+| `i`, `--include-bbox-images` | Whether to include the bounding box images for the frames that trigger or extend each detection event, along with the videos in the clips directory. |
 | `--log-level` | Logging level. Can be `DEBUG`, `INFO`, `WARNING`, or `ERROR`. Defaults to `INFO`. | `--log-level DEBUG` |
 
 > [!NOTE]

--- a/action.py
+++ b/action.py
@@ -72,6 +72,13 @@ if __name__ == "__main__":
         help="Whether to show detection frames with bounding boxes",
     )
     parser.add_argument(
+        "-i",
+        "--include-bbox-images",
+        action="store_true",
+        dest="include_bbox_images",
+        help="Whether to include the bounding box images for the frames that trigger or extend each detection event, along with the videos in the clips directory.",
+    )
+    parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",

--- a/scripts/terrestrial-demo.sh
+++ b/scripts/terrestrial-demo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 action.py ./video/terrestrial-demo.mov -c 0.45 -m 3.0 -s -b 1.0 -d -e terrestrial
+python3 action.py ./video/terrestrial-demo.mov -c 0.45 -m 3.0 -s -i -b 1.0 -d -e terrestrial

--- a/src/base_detector.py
+++ b/src/base_detector.py
@@ -110,15 +110,13 @@ class BaseDetector:
         # Return boxes[0] if it exists, otherwise return an empty list
         return boxes[0] if boxes else []
 
-    def draw_detections(self, img, boxes, title):
+    def draw_detections(self, img, boxes):
         """
-        Draw bounding boxes on the image for detected objects and show
-        in a window.
+        Draw bounding boxes on the image for detected objects and return
 
         Args:
             img: Image on which to draw bounding boxes.
             boxes: List of bounding boxes.
-            title: Title for the image window.
         """
         img = np.copy(img)
         width = img.shape[1]
@@ -162,9 +160,7 @@ class BaseDetector:
             )
 
             img = cv2.rectangle(img, (x1, y1), (x2, y2), bgr, bbox_thick)
-
-        cv2.imshow(title, img)
-        cv2.waitKey(1)
+        return img
 
     def post_processing(self, outputs):
         """


### PR DESCRIPTION
I've added a new option: `-i`/`--include-bbox-images`.  This works in a similar way to `-s`/`--show-detections`, but instead of showing the image in a window on the user's screen, it instead writes it to a `.jpg` file in the clips directory.  You can use `-i` together with `-s` (i.e., show and write) or use either one on its own (e.g., `-i` to only write them but not show them).

I think this makes it a lot easier to demonstrate what the tool is doing, and also to more easily extract images with bounding boxes.

After adding `-i` to the terrestrial demo, it produces the following files in `video/terrestrial-demo_clips`:

```sh
❯ ls video/terrestrial-demo_clips
0001-00_00-01_02.mp4 0004-00_12.jpg       0008-00_28.jpg       0012-00_44.jpg
0001-00_00.jpg       0005-00_16.jpg       0009-00_32.jpg       0013-00_49.jpg
0002-00_04.jpg       0006-00_20.jpg       0010-00_36.jpg       0014-00_53.jpg
0003-00_08.jpg       0007-00_24.jpg       0011-00_40.jpg       0015-00_57.jpg
```

We still get a single `.mp4` video clip, but we now also have a bunch of `.jpg` files, which are the frames which triggered detection or extended the detection event.  Each has the bounding boxes drawn on it.  The bounding box images are named with a number followed by the time of the image in the video: `0003-00_08.jpg` means this is bounding box image 3 and it happened at 8 seconds.

Here are a few examples of what they look like:

![0015-00_57](https://github.com/humphrem/action/assets/427398/988115c3-9da8-41ce-9f26-740f155a8e86)
![0011-00_40](https://github.com/humphrem/action/assets/427398/c99dca77-e3f3-41f5-91b9-aef5876e7e1b)
![0004-00_12](https://github.com/humphrem/action/assets/427398/366c49e4-3fe3-4c8f-9956-f03f22e86dc0)
